### PR TITLE
add code_warntype to cheatsheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -2074,6 +2074,12 @@ query = @from r in df begin
             </tr>
 
             <tr>
+              <td>Type-inferred AST</td>
+
+              <td><code>code_warntype(expr)</code></td>
+            </tr>
+
+            <tr>
               <td>JIT bytecode</td>
 
               <td><code>code_llvm(expr)</code></td>


### PR DESCRIPTION
I find this to be useful to see what the inferred types are.